### PR TITLE
refactor: added `<other_plugins_you_use>` to `Usage` example

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Add `unused-imports` to the plugins section of your `.eslintrc` configuration fi
 
 ```jsonc
 {
-	"plugins": ["unused-imports"]
+	"plugins": [<other_plugins_you_use>, "unused-imports"]
 }
 ```
 


### PR DESCRIPTION
This commit updated the `Usage` section's example with `<other_plugins_you_use>`. This will make the readme file more informative.